### PR TITLE
Remove configureondemand gradle configuration to fix build issue

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,3 @@
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx1536m
-org.gradle.configureondemand=false


### PR DESCRIPTION
Solves the following build error
`
Configuration on demand is not supported by the current version of the Android Gradle plugin since you are using Gradle version 4.6 or above. Suggestion: disable configuration on demand by setting org.gradle.configureondemand=false in your gradle.properties file or use a Gradle version less than 4.6.
`

By setting org.gradle.configureondemand to false as stated in the error message, it doesn't work so it seems that there is a bug in the configuration that could be solved by removing the property from the file.