### PR TITLE
Update to Kotlin 1.3 and migrate Coroutines away from the experimental package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext {
         versions = [
                 gradle : '4.4.1',
-                kotlin : '1.2.51',
+                kotlin : '1.3.0-rc-116',
                 code   : 1,
                 name   : '1.0.0',
                 sdk    : [
@@ -37,6 +37,7 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven { url "https://dl.bintray.com/kotlin/kotlin-eap" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
@@ -52,6 +53,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url "https://dl.bintray.com/kotlin/kotlin-eap" }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,9 @@ buildscript {
         versions = [
                 gradle : '4.4.1',
                 kotlin : '1.3.0-rc-146',
+                coroutines: [
+                        core: '0.30.0-eap13'
+                ],
                 code   : 1,
                 name   : '1.0.0',
                 sdk    : [
@@ -27,7 +30,8 @@ buildscript {
                 ],
                 test   : [
                         junit  : '4.12',
-                        mockito: '2.13.0'
+                        mockito: '2.13.0',
+                        mockitoFork: 'kotlin-release-coroutines-SNAPSHOT'
                 ],
                 util   : [
                         commons: '2.5'
@@ -54,6 +58,7 @@ allprojects {
         google()
         jcenter()
         maven { url "https://dl.bintray.com/kotlin/kotlin-eap" }
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,6 @@ allprojects {
         google()
         jcenter()
         maven { url "https://dl.bintray.com/kotlin/kotlin-eap" }
-        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,7 @@ buildscript {
                 ],
                 test   : [
                         junit  : '4.12',
-                        mockito: '2.13.0',
-                        mockitoFork: 'kotlin-release-coroutines-SNAPSHOT'
+                        mockito: '2.23.0'
                 ],
                 util   : [
                         commons: '2.5'

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     ext {
         versions = [
                 gradle : '4.4.1',
-                kotlin : '1.3.0-rc-116',
+                kotlin : '1.3.0-rc-146',
                 code   : 1,
                 name   : '1.0.0',
                 sdk    : [

--- a/fotoapparat/build.gradle
+++ b/fotoapparat/build.gradle
@@ -4,8 +4,6 @@ apply plugin: 'kotlin-android'
 
 group = 'io.fotoapparat'
 
-kotlin.experimental.coroutines 'enable'
-
 android {
     buildToolsVersion versions.android.buildTools
     compileSdkVersion versions.sdk.target
@@ -29,7 +27,7 @@ android {
 dependencies {
     compile "com.android.support:support-annotations:${versions.android.support}"
     compile "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
-    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.21'
+    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.30.0-eap13'
 
     testImplementation "junit:junit:${versions.test.junit}"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}"

--- a/fotoapparat/build.gradle
+++ b/fotoapparat/build.gradle
@@ -31,8 +31,7 @@ dependencies {
 
     testImplementation "junit:junit:${versions.test.junit}"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}"
-    //testImplementation "org.mockito:mockito-core:${versions.test.mockito}"
-    testImplementation "com.github.dzharkov.mockito:mockito-core:${versions.test.mockitoFork}"
+    testImplementation "org.mockito:mockito-core:${versions.test.mockito}"
     testImplementation "commons-io:commons-io:${versions.util.commons}"
 }
 

--- a/fotoapparat/build.gradle
+++ b/fotoapparat/build.gradle
@@ -25,13 +25,14 @@ android {
 }
 
 dependencies {
-    compile "com.android.support:support-annotations:${versions.android.support}"
-    compile "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
-    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.30.0-eap13'
+    implementation "com.android.support:support-annotations:${versions.android.support}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines.core}"
 
     testImplementation "junit:junit:${versions.test.junit}"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}"
-    testImplementation "org.mockito:mockito-core:${versions.test.mockito}"
+    //testImplementation "org.mockito:mockito-core:${versions.test.mockito}"
+    testImplementation "com.github.dzharkov.mockito:mockito-core:${versions.test.mockitoFork}"
     testImplementation "commons-io:commons-io:${versions.util.commons}"
 }
 

--- a/fotoapparat/src/main/java/io/fotoapparat/coroutines/AwaitBroadcastChannel.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/coroutines/AwaitBroadcastChannel.kt
@@ -1,9 +1,9 @@
 package io.fotoapparat.coroutines
 
-import kotlinx.coroutines.experimental.CompletableDeferred
-import kotlinx.coroutines.experimental.Deferred
-import kotlinx.coroutines.experimental.channels.BroadcastChannel
-import kotlinx.coroutines.experimental.channels.ConflatedBroadcastChannel
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.channels.BroadcastChannel
+import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 
 /**
  * A [ConflatedBroadcastChannel] which exposes a [getValue] which will [await] for at least one value.

--- a/fotoapparat/src/main/java/io/fotoapparat/coroutines/AwaitBroadcastChannel.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/coroutines/AwaitBroadcastChannel.kt
@@ -13,6 +13,10 @@ internal class AwaitBroadcastChannel<T>(
         private val deferred: CompletableDeferred<Boolean> = CompletableDeferred()
 ) : BroadcastChannel<T> by channel, Deferred<Boolean> by deferred {
 
+    override fun cancel(cause: Throwable?): Boolean {
+        return deferred.cancel() && channel.cancel()
+    }
+
     /**
      * The most recently sent element to this channel.
      */

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/CameraDevice.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/CameraDevice.kt
@@ -28,7 +28,7 @@ import io.fotoapparat.result.Photo
 import io.fotoapparat.util.FrameProcessor
 import io.fotoapparat.util.lineSeparator
 import io.fotoapparat.view.Preview
-import kotlinx.coroutines.experimental.CompletableDeferred
+import kotlinx.coroutines.CompletableDeferred
 import java.io.IOException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/Device.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/Device.kt
@@ -18,7 +18,7 @@ import io.fotoapparat.selector.LensPositionSelector
 import io.fotoapparat.util.FrameProcessor
 import io.fotoapparat.view.CameraRenderer
 import io.fotoapparat.view.FocalPointSelector
-import kotlinx.coroutines.experimental.CompletableDeferred
+import kotlinx.coroutines.CompletableDeferred
 
 
 /**

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/camera/UpdateConfigurationRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/camera/UpdateConfigurationRoutine.kt
@@ -3,7 +3,7 @@ package io.fotoapparat.routine.camera
 import io.fotoapparat.configuration.Configuration
 import io.fotoapparat.hardware.CameraDevice
 import io.fotoapparat.hardware.Device
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 
 
 /**

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/capability/GetCapabilitiesRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/capability/GetCapabilitiesRoutine.kt
@@ -2,7 +2,7 @@ package io.fotoapparat.routine.capability
 
 import io.fotoapparat.capability.Capabilities
 import io.fotoapparat.hardware.Device
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 
 /**
  * Returns the camera [Capabilities].

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/focus/FocusOnPointRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/focus/FocusOnPointRoutine.kt
@@ -3,7 +3,7 @@ package io.fotoapparat.routine.focus
 import io.fotoapparat.hardware.Device
 import io.fotoapparat.hardware.metering.FocalRequest
 import io.fotoapparat.result.FocusResult
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 
 /**
  * Focuses the camera on a particular point.

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/focus/FocusRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/focus/FocusRoutine.kt
@@ -2,7 +2,7 @@ package io.fotoapparat.routine.focus
 
 import io.fotoapparat.hardware.Device
 import io.fotoapparat.result.FocusResult
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 
 /**
  * Focuses the camera.

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/parameter/GetParametersRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/parameter/GetParametersRoutine.kt
@@ -2,7 +2,7 @@ package io.fotoapparat.routine.parameter
 
 import io.fotoapparat.hardware.Device
 import io.fotoapparat.parameter.camera.CameraParameters
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 
 /**
  * Returns the current [CameraParameters].

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/photo/TakePhotoRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/photo/TakePhotoRoutine.kt
@@ -4,7 +4,7 @@ import io.fotoapparat.exception.camera.CameraException
 import io.fotoapparat.hardware.CameraDevice
 import io.fotoapparat.hardware.Device
 import io.fotoapparat.result.Photo
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 
 /**
  * Takes a photo.

--- a/fotoapparat/src/main/java/io/fotoapparat/routine/zoom/UpdateZoomLevelRoutine.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/routine/zoom/UpdateZoomLevelRoutine.kt
@@ -4,7 +4,7 @@ import android.support.annotation.FloatRange
 import io.fotoapparat.exception.LevelOutOfRangeException
 import io.fotoapparat.hardware.Device
 import io.fotoapparat.parameter.Zoom
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 
 
 /**

--- a/fotoapparat/src/test/java/io/fotoapparat/routine/camera/UpdateCameraConfigurationRoutineTest.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/routine/camera/UpdateCameraConfigurationRoutineTest.kt
@@ -6,7 +6,7 @@ import io.fotoapparat.hardware.Device
 import io.fotoapparat.test.testCameraParameters
 import io.fotoapparat.test.testFrameProcessor
 import io.fotoapparat.test.willReturn
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock

--- a/fotoapparat/src/test/java/io/fotoapparat/routine/capability/GetCapabilitiesRoutineTest.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/routine/capability/GetCapabilitiesRoutineTest.kt
@@ -4,7 +4,7 @@ import io.fotoapparat.hardware.CameraDevice
 import io.fotoapparat.hardware.Device
 import io.fotoapparat.test.testCapabilities
 import io.fotoapparat.test.willReturn
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock

--- a/fotoapparat/src/test/java/io/fotoapparat/routine/focus/FocusRoutineTest.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/routine/focus/FocusRoutineTest.kt
@@ -7,7 +7,7 @@ import io.fotoapparat.hardware.metering.PointF
 import io.fotoapparat.parameter.Resolution
 import io.fotoapparat.result.FocusResult
 import io.fotoapparat.test.willReturn
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock

--- a/fotoapparat/src/test/java/io/fotoapparat/routine/parameter/GetParametersRoutineTest.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/routine/parameter/GetParametersRoutineTest.kt
@@ -4,7 +4,7 @@ import io.fotoapparat.hardware.CameraDevice
 import io.fotoapparat.hardware.Device
 import io.fotoapparat.test.testCameraParameters
 import io.fotoapparat.test.willReturn
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock

--- a/fotoapparat/src/test/java/io/fotoapparat/routine/photo/TakePhotoRoutineTest.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/routine/photo/TakePhotoRoutineTest.kt
@@ -6,7 +6,7 @@ import io.fotoapparat.hardware.Device
 import io.fotoapparat.result.Photo
 import io.fotoapparat.test.willReturn
 import io.fotoapparat.test.willThrow
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock

--- a/fotoapparat/src/test/java/io/fotoapparat/routine/zoom/UpdateZoomLevelRoutineTest.kt
+++ b/fotoapparat/src/test/java/io/fotoapparat/routine/zoom/UpdateZoomLevelRoutineTest.kt
@@ -6,7 +6,7 @@ import io.fotoapparat.hardware.Device
 import io.fotoapparat.parameter.Zoom
 import io.fotoapparat.test.testCapabilities
 import io.fotoapparat.test.willReturn
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyFloat


### PR DESCRIPTION
Kotlin 1.3 is getting closer and Coroutines finally are graduating to stable 🎉 
With that, all Coroutines classes are moved out of the `experimental` package which breaks Fotoapparat when using the Kotlin 1.3 RC.

This PR updates Kotlin to 1.3 RC 146 and migrates to stable Coroutines. I suggest merging this onto a separate branch and publishing a version for devs using Kotlin 1.3 RC until Kotlin 1.3 Stable has been released.

Feedback appreciated!