### PR TITLE
Remove app_name from library

### DIFF
--- a/fotoapparat/src/main/res/values/strings.xml
+++ b/fotoapparat/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Fotoapparat</string>
-</resources>


### PR DESCRIPTION
The string resource `app_name` is present from the artifact, which shouldn't be as this is a library and it should be agnostic to the consumer app.

Im deleting the whole resource file, as it's the only entry in it.