### PR TITLE
Update gradle version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
 
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'


### PR DESCRIPTION
Using this library in our project forces us to use Gradle version 3.2.1 in order to match Fotoapparat. This is because if they are not matching, it causes an issue generating the R file.

Updating the Fotoapparat Gradle version to 3.3.0 will allow us to use the latest Gradle version in our project.