### PR TITLE
Set source and target compatibility to Java 1.8 for library and dependencies

### DIFF
--- a/fotoapparat-adapters/rxjava/build.gradle
+++ b/fotoapparat-adapters/rxjava/build.gradle
@@ -14,14 +14,16 @@ android {
     }
 
     archivesBaseName = 'adapter-rxjava'
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
     compileOnly project(':fotoapparat')
     compileOnly "io.reactivex:rxjava:${versions.rx.rxJava1}"
-
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
-
     testImplementation "io.reactivex:rxjava:${versions.rx.rxJava1}"
     testImplementation "junit:junit:${versions.test.junit}"
 }

--- a/fotoapparat-adapters/rxjava2/build.gradle
+++ b/fotoapparat-adapters/rxjava2/build.gradle
@@ -14,14 +14,16 @@ android {
     }
 
     archivesBaseName = 'adapter-rxjava2'
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
     compileOnly project(':fotoapparat')
     compileOnly "io.reactivex.rxjava2:rxjava:${versions.rx.rxJava2}"
-
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
-
     testImplementation "io.reactivex.rxjava2:rxjava:${versions.rx.rxJava2}"
     testImplementation "junit:junit:${versions.test.junit}"
 }

--- a/fotoapparat/build.gradle
+++ b/fotoapparat/build.gradle
@@ -22,6 +22,10 @@ android {
     testOptions {
         unitTests.returnDefaultValues = true
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
@@ -29,7 +33,6 @@ dependencies {
     implementation "androidx.exifinterface:exifinterface:${versions.android.exifinterface}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
-
     testImplementation "junit:junit:${versions.test.junit}"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}"
     testImplementation "org.mockito:mockito-core:${versions.test.mockito}"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -25,6 +25,5 @@ android {
 dependencies {
     implementation project(':fotoapparat')
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
-
     implementation "androidx.appcompat:appcompat:${versions.android.appcompat}"
 }


### PR DESCRIPTION
I've created a C# binding library for Fotoapparat so I'm able to use it in a Xamarin based Android app.

One of the issues I encountered was that source code could not properly be desugared, the reason being that the source and target compatibility was not set. In this PR I've set the source and target compatibility to 1.8 for both the Fotoapparat library as well as the rxjava* dependencies (though perhaps it's not really needed for rxjava, I was thinking it couldn't harm).