### PR TITLE
Fix a crash when trying to access with size of a Photo

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/result/Photo.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/result/Photo.kt
@@ -1,7 +1,7 @@
 package io.fotoapparat.result
 
 import android.graphics.BitmapFactory
-import java.util.Arrays
+import java.util.*
 
 /**
  * Taken photo.

--- a/fotoapparat/src/main/java/io/fotoapparat/result/Photo.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/result/Photo.kt
@@ -1,7 +1,7 @@
 package io.fotoapparat.result
 
 import android.graphics.BitmapFactory
-import java.util.*
+import java.util.Arrays
 
 /**
  * Taken photo.
@@ -27,22 +27,20 @@ data class Photo(
     /**
      * The height of the photo.
      */
-    val height by lazy { decodedBounds.height }
+    val height: Int
+        get() = decodedBounds.outHeight
 
     /**
      * The width of the photo.
      */
-    val width by lazy { decodedBounds.width }
+    val width: Int
+        get() = decodedBounds.outWidth
 
     private val decodedBounds by lazy {
-        BitmapFactory.decodeByteArray(
-                encodedImage,
-                0,
-                encodedImage.size,
-                BitmapFactory.Options().apply {
-                            inJustDecodeBounds = true
-                        }
-        )
+        BitmapFactory.Options().apply {
+            inJustDecodeBounds = true
+            BitmapFactory.decodeByteArray(encodedImage, 0, encodedImage.size, this)
+        }
     }
 
     override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
`BitmapFactory.decodeByteArray` returns `null` when `inJustDecodeBounds == true`, the proper way to read the size is to read the `outWidth` and `outHeight` properties of the options after the call.