### PR TITLE
Make all the configuration objects have nicer toString values

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/characteristic/LensPosition.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/characteristic/LensPosition.kt
@@ -8,16 +8,22 @@ sealed class LensPosition : Characteristic {
     /**
      * The back camera.
      */
-    object Back : LensPosition()
+    object Back : LensPosition() {
+        override fun toString(): String = "LensPosition.Back"
+    }
 
     /**
      * The front camera.
      */
-    object Front : LensPosition()
+    object Front : LensPosition() {
+        override fun toString(): String = "LensPosition.Front"
+    }
 
     /**
      * An external camera.
      */
-    object External : LensPosition()
+    object External : LensPosition() {
+        override fun toString(): String = "LensPosition.External"
+    }
 
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/Orientation.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/Orientation.kt
@@ -18,12 +18,16 @@ sealed class Orientation(
         /**
          * A vertical, normal orientation.
          */
-        object Portrait : Vertical(0)
+        object Portrait : Vertical(0) {
+            override fun toString(): String = "Orientation.Vertical.Portrait"
+        }
 
         /**
          * A reversed (flipped phone) orientation.
          */
-        object ReversePortrait : Vertical(180)
+        object ReversePortrait : Vertical(180) {
+            override fun toString(): String = "Orientation.Vertical.ReversePortrait"
+        }
 
     }
 
@@ -35,12 +39,16 @@ sealed class Orientation(
         /**
          * A 90 degrees clockwise from "normal", orientation.
          */
-        object Landscape : Horizontal(90)
+        object Landscape : Horizontal(90) {
+            override fun toString(): String = "Orientation.Horizontal.Landscape"
+        }
 
         /**
          * A 90 degrees counter-clockwise from "normal", orientation.
          */
-        object ReverseLandscape : Horizontal(270)
+        object ReverseLandscape : Horizontal(270) {
+            override fun toString(): String = "Orientation.Horizontal.ReverseLandscape"
+        }
 
     }
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/AntiBandingMode.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/AntiBandingMode.kt
@@ -8,21 +8,29 @@ sealed class AntiBandingMode : Parameter {
     /**
      * Auto adjust. This should be the default.
      */
-    object Auto : AntiBandingMode()
+    object Auto : AntiBandingMode() {
+        override fun toString(): String = "AntiBandingMode.Auto"
+    }
 
     /**
      * Anti Banding is set to 50Hz light frequency.
      */
-    object HZ50 : AntiBandingMode()
+    object HZ50 : AntiBandingMode() {
+        override fun toString(): String = "AntiBandingMode.HZ50"
+    }
 
     /**
      * Anti Banding is set to 60Hz light frequency.
      */
-    object HZ60 : AntiBandingMode()
+    object HZ60 : AntiBandingMode() {
+        override fun toString(): String = "AntiBandingMode.HZ60"
+    }
 
     /**
      * Anti Banding is not supported or ignored.
      */
-    object None : AntiBandingMode()
+    object None : AntiBandingMode() {
+        override fun toString(): String = "AntiBandingMode.None"
+    }
 
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/Flash.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/Flash.kt
@@ -8,27 +8,37 @@ sealed class Flash : Parameter {
     /**
      * Camera flash will not fire.
      */
-    object Off : Flash()
+    object Off : Flash() {
+        override fun toString(): String = "Flash.Off"
+    }
 
     /**
      * Camera flash will always fire regardless light conditions.
      */
-    object On : Flash()
+    object On : Flash() {
+        override fun toString(): String = "Flash.On"
+    }
 
     /**
      * Camera flash will fire only in low light conditions.
      */
-    object Auto : Flash()
+    object Auto : Flash() {
+        override fun toString(): String = "Flash.Auto"
+    }
 
     /**
      * If deemed necessary by the camera device, a red eye reduction flash will fire during the
      * precapture sequence in low light conditions.
      */
-    object AutoRedEye : Flash()
+    object AutoRedEye : Flash() {
+        override fun toString(): String = "Flash.AutoRedEye"
+    }
 
     /**
      * Transition flash to continuously on.
      */
-    object Torch : Flash()
+    object Torch : Flash() {
+        override fun toString(): String = "Flash.Torch"
+    }
 
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/FocusMode.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/FocusMode.kt
@@ -8,40 +8,54 @@ sealed class FocusMode : Parameter {
     /**
      * Focus is not adjustable. It is always used by devices which do not support auto-focus.
      */
-    object Fixed : FocusMode()
+    object Fixed : FocusMode() {
+        override fun toString(): String = "FocusMode.Fixed"
+    }
 
     /**
      * Camera is focused at infinity.
      */
-    object Infinity : FocusMode()
+    object Infinity : FocusMode() {
+        override fun toString(): String = "FocusMode.Infinity"
+    }
 
     /**
      * Macro focus mode.
      */
-    object Macro : FocusMode()
+    object Macro : FocusMode() {
+        override fun toString(): String = "FocusMode.Macro"
+    }
 
     /**
      * Auto focus. Camera is trying to focus automatically when manually requested.
      */
-    object Auto : FocusMode()
+    object Auto : FocusMode() {
+        override fun toString(): String = "FocusMode.Auto"
+    }
 
     /**
      * Camera is constantly trying to stay in focus.
      *
      * The speed of focus change is more aggressive than [ContinuousFocusVideo].
      */
-    object ContinuousFocusPicture : FocusMode()
+    object ContinuousFocusPicture : FocusMode() {
+        override fun toString(): String = "FocusMode.ContinuousFocusPicture"
+    }
 
     /**
      * Camera is constantly trying to stay in focus.
      *
      * The speed of focus change is smoother than [ContinuousFocusPicture].
      */
-    object ContinuousFocusVideo : FocusMode()
+    object ContinuousFocusVideo : FocusMode() {
+        override fun toString(): String = "FocusMode.ContinuousFocusVideo"
+    }
 
     /**
      * The camera device will produce images with an extended depth of field.
      */
-    object Edof : FocusMode()
+    object Edof : FocusMode() {
+        override fun toString(): String = "FocusMode.Edof"
+    }
 
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/Zoom.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/Zoom.kt
@@ -8,7 +8,9 @@ sealed class Zoom {
     /**
      * The camera can only support one, fixed zoom level.
      */
-    object FixedZoom : Zoom()
+    object FixedZoom : Zoom() {
+        override fun toString(): String = "Zoom.FixedZoom"
+    }
 
     /**
      * The camera can only support a variable zoom level between (and including) 0 and [maxZoom] values.
@@ -16,6 +18,8 @@ sealed class Zoom {
      * 2.7x is returned as 270. The number of elements is [maxZoom] + 1. List is sorted from small to
      * large. First element is always 100. The last element is the zoom ratio of the maximum zoom value.
      */
-    data class VariableZoom(val maxZoom: Int, val zoomRatios: List<Int>) : Zoom()
+    data class VariableZoom(val maxZoom: Int, val zoomRatios: List<Int>) : Zoom() {
+        override fun toString(): String = "Zoom.VariableZoom(maxZoom=$maxZoom, zoomRatios=$zoomRatios)"
+    }
 
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/result/FocusResult.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/result/FocusResult.kt
@@ -8,11 +8,15 @@ sealed class FocusResult {
     /**
      * Camera is unable to focus for some reason.
      */
-    object UnableToFocus : FocusResult()
+    object UnableToFocus : FocusResult() {
+        override fun toString(): String = "FocusResult.UnableToFocus"
+    }
 
     /**
      * Camera is focused successfully.
      */
-    object Focused : FocusResult()
+    object Focused : FocusResult() {
+        override fun toString(): String = "FocusResult.Focused"
+    }
 
 }


### PR DESCRIPTION
Previously doing `Flash.Off.toString()` would return something like `io.fotoapparat.parameter.Flash$Off@a486ccc`, now it will return `Flash.Off`.