### PR TITLE
Remove lazy delegates where they aren't needed

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/FpsRange.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/FpsRange.kt
@@ -26,7 +26,5 @@ data class FpsRange(
     /**
      * `true` if the current range is fixed (min == max).
      */
-    val isFixed by lazy {
-        max == min
-    }
+    val isFixed get() = max == min
 }

--- a/fotoapparat/src/main/java/io/fotoapparat/parameter/Resolution.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/parameter/Resolution.kt
@@ -13,18 +13,17 @@ data class Resolution(
     /**
      * The total area this [Resolution] is covering.
      */
-    val area: Int by lazy { width * height }
+    val area: Int get() = width * height
 
     /**
      * The aspect ratio for this size. [Float.NaN] if invalid dimensions.
      */
-    val aspectRatio: Float by lazy {
-        when {
+    val aspectRatio: Float
+        get() = when {
             width == 0 -> Float.NaN
             height == 0 -> Float.NaN
             else -> width.toFloat() / height
         }
-    }
 
     /**
      * @return new instance of [Resolution] with width and height being swapped.

--- a/fotoapparat/src/main/java/io/fotoapparat/result/Photo.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/result/Photo.kt
@@ -1,7 +1,7 @@
 package io.fotoapparat.result
 
 import android.graphics.BitmapFactory
-import java.util.*
+import java.util.Arrays
 
 /**
  * Taken photo.
@@ -62,13 +62,10 @@ data class Photo(
     }
 
     companion object {
-
-        private val EMPTY by lazy { Photo(encodedImage = ByteArray(0), rotationDegrees = 0) }
-
         /**
          * @return empty [Photo].
          */
-        internal fun empty(): Photo = EMPTY
+        internal fun empty(): Photo = Photo(encodedImage = ByteArray(0), rotationDegrees = 0)
     }
 
 }


### PR DESCRIPTION
Using `lazy` create an extra field, requires synchronization and causes primitives to be boxed. It shouldn't used if the operation is `O(1)` and doesn't require a lot of allocations.