### PR TITLE
fix: preview orientation in sensorLandscape

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/OrientationSensor.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/hardware/orientation/OrientationSensor.kt
@@ -15,20 +15,25 @@ internal open class OrientationSensor(
     private val onOrientationChanged: (DeviceRotationDegrees) -> Unit = { deviceRotation ->
         deviceRotation.toClosestRightAngle()
                 .toOrientation()
-                .takeIf { it != lastKnownDeviceOrientation }
-                ?.let {
-                    val state = OrientationState(
-                            deviceOrientation = it,
-                            screenOrientation = device.getScreenOrientation()
-                    )
-
-                    lastKnownDeviceOrientation = state.deviceOrientation
-                    listener(state)
+                .let {
+                    val screenOrientation = device.getScreenOrientation()
+                    val deviceOrientation = it
+                    if(deviceOrientation != lastKnownDeviceOrientation
+                            || screenOrientation != lastKnowScreenOrientation){
+                        val state = OrientationState(
+                                deviceOrientation = deviceOrientation,
+                                screenOrientation = screenOrientation
+                        )
+                        lastKnowScreenOrientation = state.screenOrientation
+                        lastKnownDeviceOrientation = state.deviceOrientation
+                        listener(state)
+                    }
                 }
     }
 
     private lateinit var listener: (OrientationState) -> Unit
     private var lastKnownDeviceOrientation: Orientation = Portrait
+    private var lastKnowScreenOrientation: Orientation = Portrait
 
     constructor(
             context: Context,


### PR DESCRIPTION
**Bug:** When activity locked in sensorLandscape in AndroidManifest.xml, when the user rotates the device 180 degrees, most of the time the orientation of the preview will be upside down. The user needs to shake the device in order to reset the preview

**Analysis:** When the rotation happens the screen orientation has not been updated yet. Then the orientation does not update anymore (unless you shake the device)

**Fix:** Each time the orientation updates, also check if the screen orientation has updated too.