### PR TITLE
Fix unused inSampleSize and add scaling to decoding step

### DIFF
--- a/fotoapparat/src/main/java/io/fotoapparat/result/transformer/BitmapPhotoTransformer.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/result/transformer/BitmapPhotoTransformer.kt
@@ -51,7 +51,8 @@ private fun Photo.decodeBitmap(scaleFactor: Float): Bitmap? {
     return BitmapFactory.decodeByteArray(
             encodedImage,
             0,
-            encodedImage.size
+            encodedImage.size,
+            options
     )
 }
 

--- a/fotoapparat/src/main/java/io/fotoapparat/result/transformer/BitmapPhotoTransformer.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/result/transformer/BitmapPhotoTransformer.kt
@@ -23,7 +23,8 @@ internal class BitmapPhotoTransformer(
                 desiredResolution = desiredResolution
         )
 
-        val decodedBitmap = input.decodeBitmap(scaleFactor) ?: throw UnableToDecodeBitmapException()
+        val decodedBitmap = input.decodeBitmap(scaleFactor, originalResolution, desiredResolution)
+                ?: throw UnableToDecodeBitmapException()
 
         val bitmap = if (decodedBitmap.width == desiredResolution.width && decodedBitmap.height == desiredResolution.height) {
             decodedBitmap
@@ -44,9 +45,22 @@ internal class BitmapPhotoTransformer(
 
 }
 
-private fun Photo.decodeBitmap(scaleFactor: Float): Bitmap? {
+private fun Photo.decodeBitmap(
+        scaleFactor: Float,
+        originalResolution: Resolution,
+        desiredResolution: Resolution
+): Bitmap? {
     val options = BitmapFactory.Options()
     options.inSampleSize = scaleFactor.toInt()
+    options.inScaled = true
+
+    if (desiredResolution.width > desiredResolution.height) {
+        options.inDensity = originalResolution.width
+        options.inTargetDensity = desiredResolution.width * options.inSampleSize
+    } else {
+        options.inDensity = originalResolution.height
+        options.inTargetDensity = desiredResolution.height * options.inSampleSize
+    }
 
     return BitmapFactory.decodeByteArray(
             encodedImage,


### PR DESCRIPTION
I'm looking for ways to optimise memory usage in my app, and found some things in `BitmapPhotoTransformer` that i think can be improved.

1) There is `inSampleSize` calculation being done for decoding options, but it is never used because of typo.

2) We can skip creating another bitmap with `Bitmap.createScaledBitmap` if we add scaling step to decoding.

This way, if we want to scale down image while retaining original aspect ratio we skip `Bitmap.createScaledBitmap`, thus avoiding another bitmap allocation.

If we need to scale irregardless of aspect ratio, then `createScaledBitmap` will be used, but on already scaled down by biggest side version of the image, which is also a plus.

I also tried to measure performance benefit of memory usage.
I've modified sample to use `.toBitmap(scaled(scaleFactor = 0.22f))`
Otherwise scaleFactor pf 0.25 results in inSampleSize = 4, which wouldn't need any scaling afterwards.

Not saying this is accurate (not sure how to really measure it here), but you can see that it does have some effect.

So, sample without changes is about 180-200MB:
(uses `createScaledBitmap`)
https://i.imgur.com/JjtFVGf.png

Sample that first downsamples by `inSampleSize` and then scales by `createScaledBitmap`
is about 107-120MB:
https://i.imgur.com/T49QVbD.png

Sample that downsamples and scales in one step and skips allocation of `createScaledBitmap`:
is about 98-102MB:
https://i.imgur.com/4AI1jMU.png

