### PR TITLE
Scoped storage: Support to save shared media files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ android:
     - tools
     - platform-tools
     - tools
-    - build-tools-28.0.3
-    - android-28
+    - build-tools-29.0.2
+    - android-29
     - extra-android-m2repository
 
 before_install:
-  - yes | sdkmanager "platforms;android-28"
+  - yes | sdkmanager "platforms;android-29"
 
 script:
   - ./gradlew build test

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
                 name   : '1.0.0',
                 sdk    : [
                         minimum: 14,
-                        target : 28
+                        target : 29
                 ],
                 android: [
                         buildTools: '28.0.3',

--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ subprojects {
 buildscript {
     ext {
         versions = [
-                gradle : '4.10.2',
-                kotlin : '1.3.0',
+                gradle : '5.6.4',
+                kotlin : '1.3.50',
                 code   : 1,
                 name   : '1.0.0',
                 sdk    : [
@@ -18,10 +18,10 @@ buildscript {
                         target : 29
                 ],
                 android: [
-                        buildTools: '28.0.3',
-                        appcompat   : '1.0.1',
+                        buildTools: '29.0.2',
+                        appcompat   : '1.1.0',
                         annotation   : '1.0.0',
-                        exifinterface : '1.0.0'
+                        exifinterface : '1.1.0'
                 ],
                 rx     : [
                         rxJava1: '1.3.8',
@@ -38,7 +38,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
 
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'

--- a/fotoapparat/build.gradle
+++ b/fotoapparat/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation "androidx.annotation:annotation:${versions.android.annotation}"
     implementation "androidx.exifinterface:exifinterface:${versions.android.exifinterface}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2'
     testImplementation "junit:junit:${versions.test.junit}"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:${versions.kotlin}"
     testImplementation "org.mockito:mockito-core:${versions.test.mockito}"

--- a/fotoapparat/src/main/java/io/fotoapparat/result/PhotoResult.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/result/PhotoResult.kt
@@ -1,13 +1,15 @@
 package io.fotoapparat.result
 
+import android.content.ContentResolver
+import android.content.ContentValues
 import android.graphics.Bitmap
 import io.fotoapparat.exception.FileSaveException
 import io.fotoapparat.exif.ExifWriter
 import io.fotoapparat.log.Logger
+import io.fotoapparat.result.transformer.*
 import io.fotoapparat.result.transformer.BitmapPhotoTransformer
-import io.fotoapparat.result.transformer.ResolutionTransformer
 import io.fotoapparat.result.transformer.SaveToFileTransformer
-import io.fotoapparat.result.transformer.originalResolution
+import io.fotoapparat.result.transformer.SaveToImagesMediaStoreTransformer
 import java.io.File
 import java.util.concurrent.Future
 
@@ -40,6 +42,23 @@ class PhotoResult internal constructor(private val pendingResult: PendingResult<
             pendingResult.transform(SaveToFileTransformer(
                     file = file,
                     exifOrientationWriter = ExifWriter
+            ))
+
+    /**
+     * Saves result to the images media store.
+     *
+     * @param contentResolver needed for interacting with the MediaStore.
+     * @param contentValues bundle of info associated with the image that will be saved.
+     * @return pending operation which completes when photo is saved to the images media store.
+     * @throws FileSaveException If the file cannot be saved.
+     */
+    fun saveToImagesMediaStore(
+            contentValues: ContentValues,
+            contentResolver: ContentResolver
+    ): PendingResult<Unit> =
+            pendingResult.transform(SaveToImagesMediaStoreTransformer(
+                    contentValues = contentValues,
+                    contentResolver = contentResolver
             ))
 
     /**

--- a/fotoapparat/src/main/java/io/fotoapparat/result/transformer/SaveToImagesMediaStoreTransformer.kt
+++ b/fotoapparat/src/main/java/io/fotoapparat/result/transformer/SaveToImagesMediaStoreTransformer.kt
@@ -1,0 +1,64 @@
+package io.fotoapparat.result.transformer
+
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.os.Build
+import android.provider.MediaStore
+import io.fotoapparat.exception.FileSaveException
+import io.fotoapparat.result.Photo
+import java.io.*
+import java.lang.Exception
+
+/**
+ * Saves [Photo] to the images media store.
+ */
+internal class SaveToImagesMediaStoreTransformer(
+        private val contentValues: ContentValues,
+        private val contentResolver: ContentResolver
+) : (Photo) -> Unit {
+
+    override fun invoke(input: Photo) {
+        val imageGallery = getImageGalleryUri()
+
+        // Marks the image as pending so that just the owner has access to it during the saving process.
+        contentValues.put(MediaStore.Images.Media.IS_PENDING, 1)
+
+        val imageUri = try {
+            contentResolver.insert(imageGallery, contentValues)!!
+        } catch (e: Exception) {
+            throw FileSaveException(e)
+        }
+
+        val outputStream = try {
+            contentResolver.openOutputStream(imageUri)!!.buffered()
+        } catch (e: FileNotFoundException) {
+            throw FileSaveException(e)
+        }
+
+        try {
+            saveImage(input, outputStream)
+        } catch (e: IOException) {
+            throw FileSaveException(e)
+        }
+
+        // Releases the file.
+        contentValues.clear()
+        contentValues.put(MediaStore.Images.Media.IS_PENDING, 0)
+        contentResolver.update(imageUri, contentValues, null, null)
+    }
+
+    private fun getImageGalleryUri() = when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q ->
+            MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+        else ->
+            MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL)
+    }
+}
+
+@Throws(IOException::class)
+private fun saveImage(input: Photo, outputStream: BufferedOutputStream) {
+    outputStream.use {
+        it.write(input.encodedImage)
+        it.flush()
+    }
+}

--- a/sample/src/main/java/io/fotoapparat/sample/MainActivity.kt
+++ b/sample/src/main/java/io/fotoapparat/sample/MainActivity.kt
@@ -1,6 +1,8 @@
 package io.fotoapparat.sample
 
+import android.content.ContentValues
 import android.os.Bundle
+import android.provider.MediaStore
 import android.util.Log
 import android.view.View
 import android.widget.CompoundButton
@@ -15,7 +17,6 @@ import io.fotoapparat.parameter.Zoom
 import io.fotoapparat.result.transformer.scaled
 import io.fotoapparat.selector.*
 import kotlinx.android.synthetic.main.activity_main.*
-import java.io.File
 import kotlin.math.roundToInt
 
 class MainActivity : AppCompatActivity() {
@@ -57,14 +58,15 @@ class MainActivity : AppCompatActivity() {
 
     private fun takePicture(): () -> Unit = {
         val photoResult = fotoapparat
-                .autoFocus()
                 .takePicture()
 
         photoResult
-                .saveToFile(File(
-                        getExternalFilesDir("photos"),
-                        "photo.jpg"
-                ))
+                .saveToImagesMediaStore(
+                        ContentValues().apply {
+                            put(MediaStore.Images.Media.DISPLAY_NAME, "photo.jpg")
+                        },
+                        contentResolver
+                )
 
         photoResult
                 .toBitmap(scaled(scaleFactor = 0.25f))
@@ -193,7 +195,8 @@ private sealed class Camera(
                     flashMode = off(),
                     focusMode = firstAvailable(
                             continuousFocusPicture(),
-                            autoFocus()
+                            autoFocus(),
+                            fixed()
                     ),
                     frameProcessor = {
                         // Do something with the preview frame


### PR DESCRIPTION
**Problem**

Due to Scoped Storage, we can’t write the image directly to shared storage locations via direct file path. This approach is deprecated in android Q and will be enforced to stop using in 2020. 

From [Google's Scoped Storage best practices](https://android-developers.googleblog.com/2019/04/android-q-scoped-storage-best-practices.html):

> **Storing shared media files**. For apps that handle files that users expect to be sharable with other apps (such as photos) and be retained after the app has been uninstalled, use the MediaStore API. There are specific collections for common media files: Audio, Video, and Images. For other file types, you can store them in the new Downloads collection. To access files from the Downloads collection, apps must use the system picker.

> **Storing app-internal files**. If your app is designed to handle files not meant to be shared with other apps, store them in your package-specific directories. This helps keep files organized and limit file clutter as the OS will manage cleanup when the app is uninstalled. Calls to Context.getExternalFilesDir() will continue to work. 

We can still use `saveToFile`, making sure the constructed file path is within the scoped storage of the app. As stated before,  we just have to make sure we use `Context.getExternalFilesDir()` to save in scoped storage.

However, there's no way to save in the shared media collection locations, since that has to be done via the usage of `MediaStore`.

**Possible solution**

As an alternative to the existing `PhotoResult#saveToFile`, a new `PhotoResult#saveToImagesMediaStore` (open to other names / function signatures) could be exposed.

**TODO**

- Write rotation Exif metadata (the current ExifWriter uses a file as input) 